### PR TITLE
BugFix for AnyState => [State] transition codegen

### DIFF
--- a/Editor/InternalAPIAccess.cs
+++ b/Editor/InternalAPIAccess.cs
@@ -83,15 +83,15 @@ namespace Scio.AnimatorAccessGenerator
 			for (int layer = 0; layer < layerCount; layer++) {
 				string layerName = controller.GetLayer (layer).name;
 				UnityEditorInternal.StateMachine sm = controller.GetLayer (layer).stateMachine;
-                //Handle anyState cases. see UnityEditorInternal.StateMachine.transitions
-                {
-                    Transition[] anyTransitions = sm.GetTransitionsFromState(null);
-                    foreach (var t in anyTransitions) {
-                        TransitionInfo info = new TransitionInfo (t.uniqueNameHash, t.uniqueName, layer, layerName, 
-                            0, t.dstState.uniqueNameHash, t.atomic, t.duration, t.mute, t.offset, t.solo);
-                        callback (info);
-                    }
-                }
+                		//Handle anyState cases. see UnityEditorInternal.StateMachine.transitions
+				{
+					Transition[] anyTransitions = sm.GetTransitionsFromState(null);
+					foreach (var t in anyTransitions) {
+						TransitionInfo info = new TransitionInfo (t.uniqueNameHash, t.uniqueName, layer, layerName, 
+							0, t.dstState.uniqueNameHash, t.atomic, t.duration, t.mute, t.offset, t.solo);
+						callback (info);
+					}
+				}
 				for (int i = 0; i < sm.stateCount; i++) {
 					UnityEditorInternal.State state = sm.GetState (i);
 					Transition[] transitions = sm.GetTransitionsFromState(state);


### PR DESCRIPTION
… Without this patch, AnyState => [State] transition is not handled
with “No transition info found for transition” error message. To handle
transition from AnyState, we need to handle this case specifically by
passing null parameter. See StateMachine.transitions property getter.
