### PR TITLE
BugFix for AnyState(0).OnChange() null ptr error

### DIFF
--- a/Scripts/Events/State/AnyStateHandler.cs
+++ b/Scripts/Events/State/AnyStateHandler.cs
@@ -41,7 +41,7 @@ namespace AnimatorAccess
 		void CheckLayerStatus (LayerStatus status, Dictionary<int, StateInfo> stateInfos) {
 			if (status.State.HasChanged) {
 				StateInfo info = GetStateInfo (status.State.Current, stateInfos);
-                if (status != null && OnChange != null) {
+				if (status != null && OnChange != null) {
 					OnChange (info, status);
 				}
 			}


### PR DESCRIPTION
When we call eventManager.AnyState(0); without actually adding OnChange
would cause NullReferenceException.
Here is a small patch. :)
