### PR TITLE
Memory optimisation. Before this update, there were per frame memory all...

### DIFF
--- a/Scripts/Events/EventManager.cs
+++ b/Scripts/Events/EventManager.cs
@@ -167,14 +167,33 @@ namespace AnimatorAccess
 				}
 			}
 			if (StateHandlers != null && StateHandlers.Count > 0) {
-				foreach (StateHandler handler in StateHandlers.Values) {
-					handler.Perform (LayerStatuses, StateInfos);
-				}
+                var enumerator = StateHandlers.GetEnumerator();
+                try {
+                    while (enumerator.MoveNext()) {
+
+                        var pair = enumerator.Current;
+                        var handler = pair.Value;
+                        handler.Perform (LayerStatuses, StateInfos);
+                    }
+                }
+                finally {
+                    enumerator.Dispose();
+                }
+
 			}
 			if (TransitionHandlers != null && TransitionHandlers.Count > 0) {
-				foreach (TransitionHandler handler in TransitionHandlers.Values) {
-					handler.Perform (LayerStatuses, TransitionInfos);
-				}
+                var enumerator = TransitionHandlers.GetEnumerator();
+                try {
+                    while (enumerator.MoveNext()) {
+
+                        var pair = enumerator.Current;
+                        var handler = pair.Value;
+                        handler.Perform (LayerStatuses, TransitionInfos);
+                    }
+                }
+                finally {
+                    enumerator.Dispose();
+                }
 			}
 		}
 	}

--- a/Scripts/Events/LayerStatus.cs
+++ b/Scripts/Events/LayerStatus.cs
@@ -3,6 +3,7 @@
 //
 using UnityEngine;
 using System.Collections;
+using System.Collections.Generic;
 
 
 namespace AnimatorAccess {
@@ -18,7 +19,7 @@ namespace AnimatorAccess {
 		/// Stores the current value of T in field previous whenever set is called. This is done even if the new value
 		/// equals to current.
 		/// </summary>
-		public class HistorisedProperty <T> where T : System.IComparable
+        public class HistorisedProperty <T> where T : System.IComparable<T>
 		{
 			T previous = default (T);
 			/// <summary>
@@ -43,7 +44,10 @@ namespace AnimatorAccess {
 			/// true if Current != Previous
 			/// </summary>
 			/// <value><c>true</c> if this instance has changed; otherwise, <c>false</c>.</value>
-			public bool HasChanged { get { return !current.Equals (previous); } }
+			public bool HasChanged { get { 
+                    return 0 != current.CompareTo (previous); 
+                    //return !current.Equals (previous); 
+                } }
 		}
 	
 		/// <summary>


### PR DESCRIPTION
...ocation which can lead to the rapid GC call.
1. In mono environment, iterating via foreach is costly. I replaced those with the no-allocation friendly GetEnumerator stuffs.
2. To compare value like types via object.Equals, there is a boxing required which means another allocation.
   There is already a nice IComparable<T> interface, so I replaced the IComparable with IComparable<T>.
   Note that old call for Equals method is even not related to IComparable.

So as with these fixes, all the allocations are gone.
